### PR TITLE
Added deployment_target for tvOS

### DIFF
--- a/GHODictionary.podspec
+++ b/GHODictionary.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "GHODictionary"
-  s.version      = "1.1.0"
+  s.version      = "1.1.1"
   s.summary      = "Ordered dictionary."
   s.homepage     = "https://github.com/gabriel/GHODictionary"
   s.license      = { :type => "MIT" }
@@ -11,6 +11,8 @@ Pod::Spec.new do |s|
   s.source_files = "GHODictionary/**/*.{c,h,m}"
 
   s.ios.deployment_target = "7.0"
+
+  s.tvos.deployment_target = "10.0"
 
   s.osx.deployment_target = "10.8"
 


### PR DESCRIPTION
Seems like the only issue with tvOS support was the missing deployment target in podspec.